### PR TITLE
TownFish: Xamarin json fix

### DIFF
--- a/XamHawkDemo/XamHawkDemo/IStreetHawk/IStreetHawkPush.cs
+++ b/XamHawkDemo/XamHawkDemo/IStreetHawk/IStreetHawkPush.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace StreetHawkCrossplatform
 {
 	/// <summary>
-	/// Callback to receive raw json push.
+	/// Callback to receive raw json push. "JSON" is json formatted string such as {"key": "value"}.
 	/// </summary>
 	public delegate void RegisterForShReceivedRawJSONCallback(string title, string message, string JSON);
 

--- a/XamHawkDemo/iOS/StreetHawkIOS/StreetHawkFeeds.cs
+++ b/XamHawkDemo/iOS/StreetHawkIOS/StreetHawkFeeds.cs
@@ -67,7 +67,10 @@ namespace StreetHawkCrossplatform
 							  }
 							  if (feedDict["content"] != null)
 							  {
-								  feed.content = feedDict["content"].ToString();
+								  NSError contentError;
+								  NSData contentData = NSJsonSerialization.Serialize(feedDict["content"]/*NSDictionary type*/, 0, out contentError);
+								  NSString contentStr = new NSString(contentData, NSStringEncoding.UTF8);
+								  feed.content = contentStr.ToString();
 							  }
 							  if (feedDict["activates"] != null)
 							  {

--- a/XamHawkDemo/iOS/StreetHawkIOS/StreetHawkPush.cs
+++ b/XamHawkDemo/iOS/StreetHawkIOS/StreetHawkPush.cs
@@ -225,11 +225,14 @@ namespace StreetHawkCrossplatform
 			}
 		}
 
-		public override void shRawJsonCallbackWithTitle(string title, string message, string json)
+		public override void shRawJsonCallbackWithTitle(string title, string message, NSDictionary json)
 		{
 			if (_shRawJsonCallback != null)
 			{
-				_shRawJsonCallback(title, message, json);
+				NSError error;
+				NSData data = NSJsonSerialization.Serialize(json, 0, out error);
+				NSString jsonStr = new NSString(data, NSStringEncoding.UTF8);
+				_shRawJsonCallback(title, message, jsonStr.ToString());
 			}
 		}
 	}


### PR DESCRIPTION
Json return to customer should in format as {“key”: “value”}, not in format {“key”=“value”}. Fix it by doing json serialization, not use .ToString() operation.

Test json push and feed content, pass.

Details in ticket https://streethawk.atlassian.net/browse/IOS-993. 